### PR TITLE
Azure function SKU fix to support always on.

### DIFF
--- a/devops/Terraform/modules/az_function/variables.tf
+++ b/devops/Terraform/modules/az_function/variables.tf
@@ -13,7 +13,7 @@ variable "name_prefix" {
 
 variable "sku_name" {
   type        = string
-  default     = "Y1"
+  default     = "B1" # Note, we use a paid B1 plan by default, because we configure the function as always_on (always_on is not supported for free Y1 plan)
   description = "SKU name of the function."
 }
 


### PR DESCRIPTION
Default Azure function SKU is changed from Y1 (free) to B1 (paid) to support "always on" configuration. 
The Azure function handles domain events and we want it to be always on.