### PR TITLE
Hide unhandled exception info to the user on Api request failure

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Extensions/UnhandledExceptionExtension.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Extensions/UnhandledExceptionExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -7,9 +8,9 @@ using OneBeyond.Studio.Crosscuts.Logging;
 
 namespace OneBeyond.Studio.Obelisk.WebApi.Extensions;
 
-internal static class UnhandledExceptionLoggingExtension
+internal static class UnhandledExceptionExtension
 {
-    private static readonly ILogger Logger = LogManager.CreateLogger(nameof(UnhandledExceptionLoggingExtension));
+    private static readonly ILogger Logger = LogManager.CreateLogger(nameof(UnhandledExceptionExtension));
 
     public static void UseUnhandledExceptionLogging(this IApplicationBuilder applicationBuilder)
         => applicationBuilder.Use(LogUnhandledException);
@@ -23,6 +24,10 @@ internal static class UnhandledExceptionLoggingExtension
         catch (Exception exception)
         {
             Logger.LogError(exception, "An unhandled exception has occured while processing HTTP request");
+
+            httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(exception.Message));
+
             throw;
         }
     }

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingExtension.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingExtension.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -49,6 +50,11 @@ internal static class ExceptionHandlingExtension
         {
             httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
             await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(authzException.Message));
+        }
+        catch (Exception exception)
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(exception.Message));
         }
     }
 }

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingExtension.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/ExceptionHandling/ExceptionHandlingExtension.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
@@ -46,15 +45,15 @@ internal static class ExceptionHandlingExtension
             httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
             await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(authnException.Message));
         }
+        catch (ArgumentException argumentException) 
+        {
+            httpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+            await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(argumentException.Message));
+        }
         catch (AuthorizationPolicyFailedException authzException)
         {
             httpContext.Response.StatusCode = StatusCodes.Status403Forbidden;
             await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(authzException.Message));
-        }
-        catch (Exception exception)
-        {
-            httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
-            await httpContext.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(exception.Message));
         }
     }
 }


### PR DESCRIPTION
Prevent displaying information about an unhandled exception (Stack trace, etc...) to an user when an API request fails with an unhandled exception

## Description
- Added support for handling `ArgumentException` on `ExceptionHandlingExtensions.cs`
- `UnhandledExceptionLoggingExtension` has been renamed to `UnhandledExceptionExtension`, and in addition to log the exception it sets up the request so that information about the exception is hidden to the user

