### PR TITLE
Deprecated packages removed

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/OneBeyond.Studio.Obelisk.Authentication.Application.csproj
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/OneBeyond.Studio.Obelisk.Authentication.Application.csproj
@@ -8,11 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Stores" Version="7.0.5" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
     <PackageReference Include="Microsoft.Identity.Web" Version="2.10.0" />
     <PackageReference Include="OneBeyond.Studio.Application.SharedKernel" Version="7.1.0" />
     <PackageReference Include="OneBeyond.Studio.Domain.SharedKernel" Version="7.1.0" />

--- a/src/OneBeyond.Studio.Obelisk.WebApi/OneBeyond.Studio.Obelisk.WebApi.csproj
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/OneBeyond.Studio.Obelisk.WebApi.csproj
@@ -22,7 +22,6 @@
     <PackageReference Include="AspNetCore.HealthChecks.SqlServer" Version="6.0.2" />
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Deprecated packages removed:

Microsoft.AspNetCore.Authentication.Abstractions
Microsoft.AspNetCore.Identity
Microsoft.AspNetCore.Mvc.Formatters.Json

These packages have been deprecated as part of the .NET Package Deprecation effort.
See https://github.com/dotnet/announcements/issues/217 for more details.