### PR TITLE
Enforce limit for unsuccessful login attempts

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/SignInViaPasswordHandler.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/SignInViaPasswordHandler.cs
@@ -44,7 +44,7 @@ internal sealed class SignInViaPasswordHandler : SignInHandler<SignInViaPassword
             command.UserName,
             command.Password,
             command.RememberMe,
-            true).ConfigureAwait(false);
+            true).ConfigureAwait(false); //Note! We always lockout on failure
 
         if (!signInResult.Succeeded)
         {

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/SignInViaPasswordHandler.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/SignInViaPasswordHandler.cs
@@ -44,7 +44,7 @@ internal sealed class SignInViaPasswordHandler : SignInHandler<SignInViaPassword
             command.UserName,
             command.Password,
             command.RememberMe,
-            command.LockoutOnFailure).ConfigureAwait(false);
+            true).ConfigureAwait(false);
 
         if (!signInResult.Succeeded)
         {
@@ -62,7 +62,7 @@ internal sealed class SignInViaPasswordHandler : SignInHandler<SignInViaPassword
                 status = SignInStatus.LockedOut;
                 Logger.LogInformation("{@UserName} locked out", command.UserName);
             }
-            else if (command.LockoutOnFailure)
+            else
             {
                 var remainingAttempts = _userManager.Options.Lockout.MaxFailedAccessAttempts - authUser.AccessFailedCount;
                 Logger.LogInformation("{@UserName} attempted to login with an incorrect password. " +

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,7 +40,7 @@ public static class ServiceCollectionExtensions
                 options.Password.RequiredUniqueChars = 2;
                 // Lockout settings
                 options.Lockout.DefaultLockoutTimeSpan = SessionConstants.SessionDuration;
-                if (int.TryParse(configuration.GetOptions<string>("LockoutMaxFailedAccessAttempts"), out int maxAttempts))
+                if (int.TryParse(configuration.GetOptions<string>("LockoutMaxFailedAccessAttempts"), out var maxAttempts))
                 {
                     options.Lockout.MaxFailedAccessAttempts = maxAttempts;
                 }

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/DependencyInjection/ServiceCollectionExtensions.cs
@@ -40,7 +40,14 @@ public static class ServiceCollectionExtensions
                 options.Password.RequiredUniqueChars = 2;
                 // Lockout settings
                 options.Lockout.DefaultLockoutTimeSpan = SessionConstants.SessionDuration;
-                options.Lockout.MaxFailedAccessAttempts = 5;
+                if (int.TryParse(configuration.GetOptions<string>("LockoutMaxFailedAccessAttempts"), out int maxAttempts))
+                {
+                    options.Lockout.MaxFailedAccessAttempts = maxAttempts;
+                }
+                else
+                {
+                    options.Lockout.MaxFailedAccessAttempts = 5;
+                }
                 options.Lockout.AllowedForNewUsers = true;
             });
 

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/Commands/SignInViaPassword.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/Commands/SignInViaPassword.cs
@@ -7,8 +7,7 @@ public sealed record SignInViaPassword : SignIn
     public SignInViaPassword(
         string userName,
         string password,
-        bool rememberMe,
-        bool lockoutOnFailure = true)
+        bool rememberMe)
     {
         EnsureArg.IsNotNullOrWhiteSpace(userName, nameof(userName));
         EnsureArg.IsNotNullOrWhiteSpace(password, nameof(userName));
@@ -16,15 +15,9 @@ public sealed record SignInViaPassword : SignIn
         UserName = userName;
         Password = password;
         RememberMe = rememberMe;
-        LockoutOnFailure = lockoutOnFailure;
     }
 
     public string UserName { get; }
     public string Password { get; }
     public bool RememberMe { get; }
-
-    /// <summary>
-    /// Set this property to true if you want a user account to be locked after a number of unsuccessful login attempts
-    /// </summary>
-    public bool LockoutOnFailure { get; }
 }

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
@@ -74,6 +74,7 @@
       "en"
     ]
   },
+  "LockoutMaxFailedAccessAttempts": 5, // The number of failed access attempts allowed before a user is locked out
   "SecurityHeaders": {
     "X-Frame-Options": "SAMEORIGIN",
     "X-XSS-Protection": "1; mode=block",


### PR DESCRIPTION
Issue: there is currently no login attempt limit.

The functionality is there though, with a property called LockoutOnFailure. It's not working because LockoutOnFailure is being set to false because SignInViaPassword is created FromBody in the [HttpPost("Basic/SignIn")] endpoint. LockoutOnFailure is not part of the request so it defaults to false.

I have removed the LockoutOnFailure property, and set the handling code to always lockout after enough failures. The number of attempts can be set through the config file.