### PR TITLE
Fix the way MediatR is registered

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
@@ -228,7 +228,8 @@ public static class Program
             });
 
         services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(
-            Assembly.GetExecutingAssembly(), 
+            Assembly.GetExecutingAssembly(),
+            typeof(AssemblyMark).Assembly,
             typeof(Authentication.Application.AssemblyMark).Assembly));
 
         services.AddTransient<IConfigureOptions<SwaggerGenOptions>, ConfigureSwaggerOptions>();


### PR DESCRIPTION
I noticed the issue when trying to edit a User results, which resulted in an error 500 due to MediatR not being able to find the handler. Jose Quintero gave me this fix, which did the trick. 