### PR TITLE
Add endpoint for retrieving password requirements

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
@@ -4,7 +4,9 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 using OneBeyond.Studio.Crosscuts.Utilities.Identities;
 using OneBeyond.Studio.Obelisk.Application.Exceptions;
 using OneBeyond.Studio.Obelisk.Application.Features.Users.Dto;
@@ -26,16 +28,20 @@ public sealed class AuthController : ControllerBase
 {
     private readonly IMediator _mediator;
     private readonly ClientApplicationLinkGenerator _clientApplicationLinkGenerator;
+    private readonly IOptions<IdentityOptions> _identityOptions;
 
     public AuthController(
         IMediator mediator,
-        ClientApplicationLinkGenerator clientApplicationLinkGenerator)
+        ClientApplicationLinkGenerator clientApplicationLinkGenerator,
+        IOptions<IdentityOptions> identityOptions)
     {
         EnsureArg.IsNotNull(mediator, nameof(mediator));
         EnsureArg.IsNotNull(clientApplicationLinkGenerator, nameof(clientApplicationLinkGenerator));
+        EnsureArg.IsNotNull(identityOptions, nameof(identityOptions));
 
         _mediator = mediator;
         _clientApplicationLinkGenerator = clientApplicationLinkGenerator;
+        _identityOptions = identityOptions;
     }
 
     [Authorize]
@@ -118,6 +124,10 @@ public sealed class AuthController : ControllerBase
             HttpContext.User?.Identity?.TryGetLoginId() ?? throw new ObeliskApplicationException("Failed to retrieve the ID of a logged in user"),
             changePassword.OldPassword, 
             changePassword.NewPassword), cancellationToken);
+
+    [HttpGet("PasswordRequirements")]
+    public PasswordOptions PasswordRequirements()
+        => _identityOptions.Value.Password;
 
     /// <summary>
     /// Empty action used for keeping session alive when user pressed cancel logout.


### PR DESCRIPTION
As requested by Alexis, I have added an endpoint that allows the frontend to keep its password input validation rules in sync with the backend automatically. 