### PR TITLE
Automatically fill in the version parameter in Swagger UI

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
@@ -219,6 +219,7 @@ public static class Program
             (options) =>
             {
                 options.GroupNameFormat = "'v'VVV";
+                options.SubstituteApiVersionInUrl = true;
             });
 
         services.Configure<ApiBehaviorOptions>(


### PR DESCRIPTION
For feature #78 

Swagger now shows like:
![image](https://github.com/onebeyond/onebeyond-studio-obelisk/assets/125360868/3f67318d-223c-4bb6-99b6-826eeb6055af)
(version in route matches the api version selection and the version parameter is removed)
