### PR TITLE
Added EnableNoneSameSiteModeFor2FACookie

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
@@ -7,10 +7,12 @@ using System.Threading.Tasks;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
 using HealthChecks.UI.Client;
+using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
@@ -263,6 +265,17 @@ public static class Program
         services.AddMixedSourceBinder(); //Mixed source binder used to gather commands, queries and dtos in controllers from mixed sources: body and route
 
         services.AddLocalization(options => options.ResourcesPath = "Localizations/Resources");
+
+        if (configuration.GetValue<bool>("CookieAuthN:EnableNoneSameSiteModeFor2FACookie"))
+        {
+            // If 'EnableNoneSameSiteModeFor2FACookie' is set to true in the configuration,
+            // this block sets the 'SameSite' attribute of the 'TwoFactorUserIdScheme' cookie 
+            // to 'SameSiteMode.None'. This allows the cookie to be included in cross-site requests.
+            // Note: Use this setting with caution as it could potentially decrease security protections. 
+            services.Configure<CookieAuthenticationOptions>(
+                IdentityConstants.TwoFactorUserIdScheme,
+                x => x.Cookie.SameSite = SameSiteMode.None);
+        }
 
         services.AddHealthChecks(environment, configuration);
     }

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.Development.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.Development.json
@@ -4,7 +4,8 @@
   },
 
   "CookieAuthN": {
-    "AllowCrossSiteCookies": true
+    "AllowCrossSiteCookies": true,
+    "EnableNoneSameSiteModeFor2FACookie": false
   },
 
   "Cors": {

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.QA.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.QA.json
@@ -3,7 +3,8 @@
     "Url": "https://polite-sea-0eb46e203.3.azurestaticapps.net"
   },
   "CookieAuthN": {
-    "AllowCrossSiteCookies": true
+    "AllowCrossSiteCookies": true,
+    "EnableNoneSameSiteModeFor2FACookie": true
   },
   "Cors": {
     "AllowedOrigins:QA": "https://polite-sea-0eb46e203.3.azurestaticapps.net"

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
@@ -15,7 +15,8 @@
     "ApplicationConnectionString": "Server=localhost; Database=ObeliskDev; Trusted_Connection=True;MultipleActiveResultSets=true;TrustServerCertificate=true;"
   },
   "CookieAuthN": {
-    "AllowCrossSiteCookies": false
+    "AllowCrossSiteCookies": false,
+    "EnableNoneSameSiteModeFor2FACookie": false //Setting this to 'true' will apply the 'SameSite=None' attribute to the Two-Factor Authentication cookie, instead of the default 'SameSite=Lax' setting. This allows the 2FA cookie to be sent along with cross-site requests, potentially enhancing interoperability with third-party websites but reducing some security protections.
   },
   "Cors": {},
   "DomainEvents": {


### PR DESCRIPTION
In this pull request, a new configuration setting EnableNoneSameSiteModeFor2FACookie has been introduced. This option allows us to control the 'SameSite' attribute for the 'TwoFactorUserIdScheme' cookie.

When set to true, the 'SameSite' attribute of the 'TwoFactorUserIdScheme' cookie is set to SameSiteMode.None. This allows the cookie to be included in cross-site requests, which may enhance interoperability with third-party websites.

Please note that while this may increase compatibility with some third-party websites or services, it could also potentially decrease security protections. Therefore, this setting should be used judiciously, taking into account the specific needs and security considerations of your application.

Please review this change and let me know if you have any questions or concerns.