### PR TITLE
Add more descriptive error messages on password reset fail

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/ResetPasswordHandler.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/ResetPasswordHandler.cs
@@ -6,12 +6,13 @@ using EnsureThat;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
 using OneBeyond.Studio.Obelisk.Authentication.Application.Entities;
+using OneBeyond.Studio.Obelisk.Authentication.Domain;
 using OneBeyond.Studio.Obelisk.Authentication.Domain.Commands;
 using OneBeyond.Studio.Obelisk.Authentication.Domain.Exceptions;
 
 namespace OneBeyond.Studio.Obelisk.Authentication.Application.CommandHandlers;
 
-internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword>
+internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword, ResetPasswordStatus>
 {
     private readonly UserManager<AuthUser> _userManager;
 
@@ -23,29 +24,22 @@ internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword>
         _userManager = userManager;
     }
 
-    public async Task Handle(ResetPassword command, CancellationToken cancellationToken)
+    public async Task<ResetPasswordStatus> Handle(ResetPassword command, CancellationToken cancellationToken)
     {
         EnsureArg.IsNotNull(command, nameof(command));
 
-        ValidateInput(command);
-
-        var identityUser = await FindUserByIdAsync(command.UserId);
-
-        await VerifyTokenAsync(identityUser, command.Token);
-
-        await ResetUserPasswordAsync(identityUser, command.Token, command.Password);
-    }
-
-    private void ValidateInput(ResetPassword command)
-    {
-        if (command.Token is null)
+        try
         {
-            throw new ArgumentException("Invalid token.");
+            var identityUser = await FindUserByIdAsync(command.UserId);
+            return await ResetUserPasswordAsync(identityUser, command.Token, command.Password);
         }
-
-        if (command.UserId is null)
+        catch (AuthLoginNotFoundException)
         {
-            throw new ArgumentException("Invalid user ID.");
+            return ResetPasswordStatus.InvalidToken;
+        }
+        catch (Exception)
+        {
+            return ResetPasswordStatus.OtherError;
         }
     }
 
@@ -56,28 +50,23 @@ internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword>
         return identityUser is null ? throw new AuthLoginNotFoundException($"Login with the {userId} is not found.") : identityUser;
     }
 
-    private async Task VerifyTokenAsync(AuthUser identityUser, string token)
-    {
-        var isTokenValid = await _userManager.VerifyUserTokenAsync(
-            identityUser,
-            _userManager.Options.Tokens.PasswordResetTokenProvider,
-            "ResetPassword",
-            token);
-
-        if (!isTokenValid)
-        {
-            throw new AuthLoginNotFoundException("Invalid token.");
-        }
-    }
-
-    private async Task ResetUserPasswordAsync(AuthUser identityUser, string token, string newPassword)
+    private async Task<ResetPasswordStatus> ResetUserPasswordAsync(AuthUser identityUser, string token, string newPassword)
     {
         var resetPasswordResult = await _userManager.ResetPasswordAsync(identityUser, token, newPassword).ConfigureAwait(false);
-
+        var resetPasswordStatus = ResetPasswordStatus.Success;
         if (!resetPasswordResult.Succeeded)
         {
-            throw new AuthException(string.Join(",", resetPasswordResult.Errors.Select(x => x.Description)));
+            var firstErrorCode = resetPasswordResult.Errors.FirstOrDefault()?.Code;
+            if (firstErrorCode == null)
+            {
+                resetPasswordStatus = ResetPasswordStatus.OtherError;
+            }
+            else if (firstErrorCode == ResetPasswordStatus.InvalidToken.ToString())
+            {
+                resetPasswordStatus = ResetPasswordStatus.InvalidToken;
+            }
         }
+        return resetPasswordStatus;
     }
 
 }

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/ResetPasswordHandler.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Application/CommandHandlers/ResetPasswordHandler.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using EnsureThat;
 using MediatR;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using OneBeyond.Studio.Crosscuts.Logging;
 using OneBeyond.Studio.Obelisk.Authentication.Application.Entities;
 using OneBeyond.Studio.Obelisk.Authentication.Domain;
 using OneBeyond.Studio.Obelisk.Authentication.Domain.Commands;
@@ -15,6 +17,7 @@ namespace OneBeyond.Studio.Obelisk.Authentication.Application.CommandHandlers;
 internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword, ResetPasswordStatus>
 {
     private readonly UserManager<AuthUser> _userManager;
+    private static readonly ILogger Logger = LogManager.CreateLogger<ResetPasswordHandler>();
 
     public ResetPasswordHandler(
         UserManager<AuthUser> userManager
@@ -33,12 +36,14 @@ internal sealed class ResetPasswordHandler : IRequestHandler<ResetPassword, Rese
             var identityUser = await FindUserByIdAsync(command.UserId);
             return await ResetUserPasswordAsync(identityUser, command.Token, command.Password);
         }
-        catch (AuthLoginNotFoundException)
+        catch (AuthLoginNotFoundException ex)
         {
+            Logger.LogInformation(ex.Message);
             return ResetPasswordStatus.InvalidToken;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            Logger.LogInformation("{@UserId} reset password exception: {@exception}", command.UserId, ex.Message);
             return ResetPasswordStatus.OtherError;
         }
     }

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/Commands/ResetPassword.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/Commands/ResetPassword.cs
@@ -3,7 +3,7 @@ using MediatR;
 
 namespace OneBeyond.Studio.Obelisk.Authentication.Domain.Commands;
 
-public sealed record ResetPassword : IRequest
+public sealed record ResetPassword : IRequest<ResetPasswordStatus>
 {
     public ResetPassword(
         string userId,

--- a/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/ResetPasswordStatus.cs
+++ b/src/OneBeyond.Studio.Obelisk.Authentication/OneBeyond.Studio.Obelisk.Authentication.Domain/ResetPasswordStatus.cs
@@ -1,0 +1,8 @@
+namespace OneBeyond.Studio.Obelisk.Authentication.Domain;
+
+public enum ResetPasswordStatus
+{
+    Success,
+    InvalidToken,
+    OtherError
+}

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
@@ -59,7 +59,7 @@ public sealed class AuthController : ControllerBase
         => _mediator.Send(signInViaPassword, cancellationToken);
 
     [HttpPost("Basic/SignInWithTwoFA")]
-        public Task<SignInResult> SignInWithTwoFA(
+    public Task<SignInResult> SignInWithTwoFA(
         [FromBody] SignInTfa signInViaTfa,
         CancellationToken cancellationToken)
         => _mediator.Send(signInViaTfa, cancellationToken);
@@ -78,7 +78,7 @@ public sealed class AuthController : ControllerBase
 
     [HttpPost("ForgotPassword")]
     public async Task ForgotPassword(
-        [FromBody] ForgotPasswordRequest forgotPassword, 
+        [FromBody] ForgotPasswordRequest forgotPassword,
         CancellationToken cancellationToken)
     {
         // To guard against timing attacks
@@ -93,7 +93,7 @@ public sealed class AuthController : ControllerBase
             await _mediator.Send(
                 new SendResetPasswordEmail(
                         resetPasswordTokenResult.LoginId,
-                        _clientApplicationLinkGenerator.GetResetPasswordUrl(resetPasswordTokenResult.LoginId,resetPasswordTokenResult.Value)),
+                        _clientApplicationLinkGenerator.GetResetPasswordUrl(resetPasswordTokenResult.LoginId, resetPasswordTokenResult.Value)),
                     cancellationToken).ConfigureAwait(false);
         }
         catch (Exception)
@@ -104,33 +104,25 @@ public sealed class AuthController : ControllerBase
     }
 
     [HttpPost("ResetPassword")]
-    public async Task ResetPassword(
-        [FromBody] ResetPasswordRequest resetPassword, 
+    public async Task<ResetPasswordStatus> ResetPassword(
+        [FromBody] ResetPasswordRequest resetPassword,
         CancellationToken cancellationToken)
     {
-        try
-        {
-            await _mediator.Send(new ResetPassword(
-                   resetPassword.UserId,
-                   resetPassword.Token,
-                   resetPassword.Password),
-               cancellationToken).ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            // Don't throw exception so we don't reveal which emails are currently in use
-            Logger.LogError("Failed to reset user password for user: {exception}", ex.Message);
-        }
+        return await _mediator.Send(new ResetPassword(
+               resetPassword.UserId,
+               resetPassword.Token,
+               resetPassword.Password),
+           cancellationToken).ConfigureAwait(false);
     }
 
     [Authorize]
     [HttpPost("ChangePassword")]
     public Task<ChangePasswordResult> ChangePassword(
-        [FromBody] ChangePasswordRequest changePassword, 
+        [FromBody] ChangePasswordRequest changePassword,
         CancellationToken cancellationToken)
         => _mediator.Send(new ChangePassword(
             HttpContext.User?.Identity?.TryGetLoginId() ?? throw new ObeliskApplicationException("Failed to retrieve the ID of a logged in user"),
-            changePassword.OldPassword, 
+            changePassword.OldPassword,
             changePassword.NewPassword), cancellationToken);
 
     [HttpGet("PasswordRequirements")]

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
@@ -110,16 +110,14 @@ public sealed class AuthController : ControllerBase
     }
 
     [HttpPost("ResetPassword")]
-    public async Task<ResetPasswordStatus> ResetPassword(
+    public Task<ResetPasswordStatus> ResetPassword(
         [FromBody] ResetPasswordRequest resetPassword,
         CancellationToken cancellationToken)
-    {
-        return await _mediator.Send(new ResetPassword(
-               resetPassword.UserId,
-               resetPassword.Token,
-               resetPassword.Password),
-           cancellationToken).ConfigureAwait(false);
-    }
+        => _mediator.Send(new ResetPassword(
+            resetPassword.UserId,
+            resetPassword.Token,
+            resetPassword.Password),
+            cancellationToken);
 
     [Authorize]
     [HttpPost("ChangePassword")]


### PR DESCRIPTION
This was slightly more 'tricky' than I anticipated, as we get back an IEnumerable of errors if the reset password operation fails. I've taken the approach of grabbing the first error, and converting it to an enum so that we can maintain a consistent contract (like how we handle sign in).

I also removed a lot of the validation code in ResetPasswordHandler as it seemed to me like the _userManager.ResetPasswordAsync method would handle these cases. 