### PR TITLE
Improved logging in Application Insights for Workers

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Program.cs
@@ -83,16 +83,12 @@ public static class Program
 
             ConfigureLogging(builder.Host);
 
-            builder.Host.ConfigureServices(
-                (hostBuilerContext, serviceCollection) =>
-                    ConfigureServices(hostBuilerContext, serviceCollection));
+            builder.Host.ConfigureServices(ConfigureServices);
 
             // Autofac factory will automatically populate services defined above into its container
             builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
 
-            builder.Host.ConfigureContainer<ContainerBuilder>(
-                (hostBuilderContext, containerBuilder) =>
-                    ConfigureAutofacServices(hostBuilderContext, containerBuilder));
+            builder.Host.ConfigureContainer<ContainerBuilder>(ConfigureAutofacServices);
 
             var app = builder.Build();
 

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.QA.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.QA.json
@@ -11,7 +11,33 @@
   "Serilog": {
     "Using:ApplicationInsights": "Serilog.Sinks.ApplicationInsights",
     "MinimumLevel": {
-      "Default": "Information"
+      "Default": "Information",
+      "Override": {
+        // Produces:
+        // "Executed action method {ActionName}, returned result {ActionResult} in {ElapsedMilliseconds}ms."
+        // "Executed action {ActionName} in {ElapsedMilliseconds}ms"
+        // "Route matched with {RouteData}. Executing controller action with signature {MethodInfo} on controller {Controller} ({AssemblyName})."
+        // "Executing action method {ActionName} - Validation state: {ValidationState}"
+        "Microsoft.AspNetCore.Mvc.Infrastructure.ControllerActionInvoker": "Warning",
+        // Produces:
+        // "Executing {ObjectResultType}, writing value of type '{Type}'."
+        "Microsoft.AspNetCore.Mvc.Infrastructure.ObjectResultExecutor": "Warning",
+        // Produces:
+        // "Executing endpoint '{EndpointName}'"
+        // "Executed endpoint '{EndpointName}'"
+        "Microsoft.AspNetCore.Routing.EndpointMiddleware": "Warning",
+        // Produces:
+        // "Sending file. Request path: '{VirtualPath}'. Physical path: '{PhysicalPath}'"
+        // "The file {Path} was not modified"
+        "Microsoft.AspNetCore.StaticFiles.StaticFileMiddleware": "Warning",
+        "Microsoft.EntityFrameworkCore.Database.Command": "Warning",
+        "Microsoft.AspNetCore.Hosting.Diagnostics": "Warning",
+        "Microsoft.EntityFrameworkCore.Infrastructure": "Warning",
+        "CookieAuthenticationFlow": "Warning",
+        "PermissionEnforcementFilterAttribute": "Warning",
+        "Microsoft.AspNetCore.Mvc.NewtonsoftJson.NewtonsoftJsonResultExecutor": "Warning",
+        "Microsoft.AspNetCore": "Warning"
+      }
     },
     "WriteTo:ApplicationInsights": {
       "Name": "ApplicationInsights",

--- a/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.Reflection;
 using Autofac;
 using Autofac.Extensions.DependencyInjection;
+using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,10 +20,8 @@ using OneBeyond.Studio.Obelisk.Application.DependencyInjection;
 using OneBeyond.Studio.Obelisk.Infrastructure.DependencyInjection;
 using OneBeyond.Studio.Obelisk.Workers.AmbientContexts;
 using Serilog;
-
-using SendGridEmailSender = OneBeyond.Studio.EmailProviders.SendGrid;
 using FolderEmailSender = OneBeyond.Studio.EmailProviders.Folder;
-using Microsoft.ApplicationInsights.Extensibility;
+using SendGridEmailSender = OneBeyond.Studio.EmailProviders.SendGrid;
 
 namespace OneBeyond.Studio.Obelisk.Workers;
 

--- a/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
@@ -27,7 +27,7 @@ namespace OneBeyond.Studio.Obelisk.Workers;
 
 internal static class Program
 {
-    public static void Main(string[] args)
+    public static void Main(string[] _)
     {
         Log.Logger = new LoggerConfiguration()
             .WriteTo.Console()

--- a/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
@@ -92,7 +92,9 @@ internal static class Program
         ConfigureSerilog(hostBuilderContext);
     }
 
-    private static void ConfigureSerilog(HostBuilderContext hostBuilderContext)
+    private static void ConfigureSerilog(
+        HostBuilderContext hostBuilderContext,
+        IServiceCollection serviceCollection)
     {
         var loggerConfiguration = new LoggerConfiguration()
                .ReadFrom.Configuration(hostBuilderContext.Configuration);
@@ -107,6 +109,9 @@ internal static class Program
                     TelemetryConfiguration.CreateDefault(),
                     TelemetryConverter.Traces)
                 .CreateLogger();
+
+        serviceCollection.AddLogging(
+            cfg => cfg.AddSerilog(Log.Logger, true));
     }
 
     private static void ConfigureContainerBuilder(

--- a/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
+++ b/src/OneBeyond.Studio.Obelisk.Workers/Program.cs
@@ -89,7 +89,7 @@ internal static class Program
         }
 
         serviceCollection.AddApplicationInsightsTelemetryWorkerService();
-        ConfigureSerilog(hostBuilderContext);
+        ConfigureSerilog(hostBuilderContext, serviceCollection);
     }
 
     private static void ConfigureSerilog(

--- a/src/OneBeyond.Studio.Obelisk.Workers/appsettings.QA.json
+++ b/src/OneBeyond.Studio.Obelisk.Workers/appsettings.QA.json
@@ -1,14 +1,7 @@
 {
   "Serilog": {
-    "Using:ApplicationInsights": "Serilog.Sinks.ApplicationInsights",
     "MinimumLevel": {
       "Default": "Information"
-    },
-    "WriteTo:ApplicationInsights": {
-      "Name": "ApplicationInsights",
-      "Args": {
-        "TelemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-      }
     }
   }
 }

--- a/src/OneBeyond.Studio.Obelisk.Workers/host.json
+++ b/src/OneBeyond.Studio.Obelisk.Workers/host.json
@@ -4,7 +4,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "excludedTypes": "Request"
+        "excludedTypes": "Request;Exception"
       }
     }
   }


### PR DESCRIPTION
Improved logging in Application Insights for Workers

## Description
The implementation through appsettings.json is not fully integrated with the automatic Monitoring capabilities provided by Application Insights for Azure Functions.
Specifically, the "operation_Id" and the custom dimension "InvocationId" properties given by Azure Functions are not set properly.
Therefore this change updates the mechanism to use a hardcoded telemetry provider that works properly.
Also updated the Serilog config for the WebApp to avoid excessive logging of Microsoft-related stuff.

## Motivation and Context
Easier monitoring

## Screenshots:
Before:
![image](https://github.com/onebeyond/onebeyond-studio-obelisk/assets/21156129/e3536fba-071e-4b29-8cfe-32350b6e28e5)

After:
![image](https://github.com/onebeyond/onebeyond-studio-obelisk/assets/21156129/c3e20f43-c31b-41c2-ac43-b296ddea0fce)
