### PR TITLE
Remove Exception from excluded types on Sampling

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Workers/host.json
+++ b/src/OneBeyond.Studio.Obelisk.Workers/host.json
@@ -4,7 +4,7 @@
     "applicationInsights": {
       "samplingSettings": {
         "isEnabled": true,
-        "excludedTypes": "Request;Exception"
+        "excludedTypes": "Request"
       }
     }
   }


### PR DESCRIPTION
Excluding exceptions from Application Insights sampling might lead to an excessive amount of data being stored if the Azure Function cannot start for any reason. 