### PR TITLE
Force Sonar analyzer to use JDK 17 by default

### DIFF
--- a/devops/build-jobs.yml
+++ b/devops/build-jobs.yml
@@ -80,6 +80,8 @@ jobs:
           summaryFileLocation: $(Agent.TempDirectory)/**/coverage.cobertura.xml
 
       - task: SonarCloudAnalyze@1
+        inputs:
+          jdkversion: "JAVA_HOME_17_X64"
         displayName: "Analyze SonarCloud"
         condition: and(succeeded(), eq(variables['run.sonar'], 'true'))
 


### PR DESCRIPTION
Force Sonar analyzer to use JDK 17 by default 