### PR TITLE
Access-Control-Expose-Headers header added

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/Constants/SecurityMiddlewareConstants.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/Constants/SecurityMiddlewareConstants.cs
@@ -5,13 +5,10 @@ public static class SecurityMiddlewareConstants
     public static class AccessControlExposeHeadersConstants
     {
         /// <summary>
-        /// Header value for content-security-policy
+        /// Header value for Access-Control-Expose-Headers
         /// </summary>
         public const string Header = "Access-Control-Expose-Headers";
 
-        /// <summary>
-        /// Disables content sniffing
-        /// </summary>
         public const string ContentDisposition = "Content-Disposition";
     }
 

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/Constants/SecurityMiddlewareConstants.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/Constants/SecurityMiddlewareConstants.cs
@@ -2,6 +2,18 @@ namespace OneBeyond.Studio.Obelisk.WebApi.Middlewares.Security.Constants;
 
 public static class SecurityMiddlewareConstants
 {
+    public static class AccessControlExposeHeadersConstants
+    {
+        /// <summary>
+        /// Header value for content-security-policy
+        /// </summary>
+        public const string Header = "Access-Control-Expose-Headers";
+
+        /// <summary>
+        /// Disables content sniffing
+        /// </summary>
+        public const string ContentDisposition = "Content-Disposition";
+    }
 
     public static class ContentSecurityPolicyConstants
     {

--- a/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/SecurityHeadersBuilder.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Middlewares/Security/SecurityHeadersBuilder.cs
@@ -20,7 +20,13 @@ internal sealed class SecurityHeadersBuilder
 
         AddContentTypeOptionsNoSniff();
 
-        var headerValue = securityHeaders.GetValue<string>(FrameOptionsConstants.Header);
+        var headerValue = securityHeaders.GetValue<string>(AccessControlExposeHeadersConstants.Header);
+        if (!string.IsNullOrEmpty(headerValue))
+        {
+            AddCustomHeader(AccessControlExposeHeadersConstants.Header, headerValue);
+        }
+
+        headerValue = securityHeaders.GetValue<string>(FrameOptionsConstants.Header);
         if (string.IsNullOrEmpty(headerValue))
         {
             AddFrameOptionsSameOrigin();

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
@@ -80,7 +80,7 @@
     "X-XSS-Protection": "1; mode=block",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
     "X-Permitted-Cross-Domain-Policies": "none",
-    "Access-Control-Expose-Headers": "Content-Disposition" //We need to expose this header in case if we're planning to dowlnoad files in browser (for CORS requests). Content-Disposition header contains file name
+    "Access-Control-Expose-Headers": "Content-Disposition" //We need to expose this header in case if we're planning to download files in browser (for CORS requests). Content-Disposition header contains file name
   },
   "Serilog": {
     "Enrich:FromLogContext": "FromLogContext",

--- a/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/appsettings.json
@@ -79,7 +79,8 @@
     "X-Frame-Options": "SAMEORIGIN",
     "X-XSS-Protection": "1; mode=block",
     "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
-    "X-Permitted-Cross-Domain-Policies": "none"
+    "X-Permitted-Cross-Domain-Policies": "none",
+    "Access-Control-Expose-Headers": "Content-Disposition" //We need to expose this header in case if we're planning to dowlnoad files in browser (for CORS requests). Content-Disposition header contains file name
   },
   "Serilog": {
     "Enrich:FromLogContext": "FromLogContext",


### PR DESCRIPTION
By default, for CORS requests most of the headers in the response are hidden, only `Content-type` and `Content-Length` are visible. `Content-Disposition` header contains information about the file name, so we explicitly need to make it visible in case if we're planning to download files.