### PR TITLE
Terraform random_password generator, special charecters modified

### DIFF
--- a/devops/Terraform/modules/random_password_in_key_vault/module.tf
+++ b/devops/Terraform/modules/random_password_in_key_vault/module.tf
@@ -5,7 +5,13 @@ resource "random_password" "sql_server_password" {
   min_numeric      = 1
   min_upper        = 1
   min_special      = 1
-  override_special = "!#$%&*-_=+?@£.,[]"
+  override_special = "!#$%*-_=+?@.[]()"
+
+  lifecycle {
+    ignore_changes = [
+      length
+    ]
+  }
 }
 
 resource "azurerm_key_vault_secret" "sql_server_passwords" {


### PR DESCRIPTION
"&", "£" and "," special charecters removed from the list of special characters to be used for secrets and passwords generation. 

"&", "£" - when creating a secret, Terraform converts those charecters into unicode, and then we have issues using those secrets in SQL server passwords and SignalR secrets (SignalR secrets are transferred via HTTP and must be ASCII)

"," - creates and issue when used in the SQL password in the connection string (considered as a delimiter)