### PR TITLE
removed = char from password generation as this is not valid in sql connection strings

### DIFF
--- a/devops/Terraform/modules/random_password_in_key_vault/module.tf
+++ b/devops/Terraform/modules/random_password_in_key_vault/module.tf
@@ -5,7 +5,7 @@ resource "random_password" "sql_server_password" {
   min_numeric      = 1
   min_upper        = 1
   min_special      = 1
-  override_special = "!#$%*-_=+?@.[]()"
+  override_special = "!#$%*-_+?@.[]()"
 
   lifecycle {
     ignore_changes = [


### PR DESCRIPTION
char is invalid for sql server connection strings

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
