### PR TITLE
"Deploy Workers Function" fix by replacing task AzureFunctionApp@1 with inlineScript

### DIFF
--- a/devops/rollout-deploy-stage-jobs.yml
+++ b/devops/rollout-deploy-stage-jobs.yml
@@ -148,19 +148,8 @@ jobs:
                 appSettings: >
                   -ASPNETCORE_ENVIRONMENT "${{parameters.runtimeEnvironment}}"
 
-            # [BUG]: deployment gets stuck and fails sporadically:
+            # [BUG]: using inline script instead of AzureFunctionApp, as deployment gets stuck and fails sporadically:
             # https://github.com/microsoft/azure-pipelines-tasks/issues/18766
-            # - task: AzureFunctionApp@1
-            #   displayName: "Deploy Workers Function"
-            #   inputs:
-            #     azureSubscription: ${{parameters.devOpsServiceConnection}}
-            #     appType: functionAppLinux
-            #     appName: "$(Terraform_Output.workers_app_name)"
-            #     package: "$(Pipeline.Workspace)/${{parameters.buildArtifactPipelineId}}/Workers/Workers.zip"
-            #     deploymentMethod: runFromPackage
-            #     appSettings: >
-            #       -AZURE_FUNCTIONS_ENVIRONMENT "${{parameters.runtimeEnvironment}}"
-
             - task: AzureCLI@2
               displayName: "Deploy Workers Function"
               inputs:

--- a/devops/rollout-deploy-stage-jobs.yml
+++ b/devops/rollout-deploy-stage-jobs.yml
@@ -148,13 +148,25 @@ jobs:
                 appSettings: >
                   -ASPNETCORE_ENVIRONMENT "${{parameters.runtimeEnvironment}}"
 
-            - task: AzureFunctionApp@1
+            # [BUG]: deployment gets stuck and fails sporadically:
+            # https://github.com/microsoft/azure-pipelines-tasks/issues/18766
+            # - task: AzureFunctionApp@1
+            #   displayName: "Deploy Workers Function"
+            #   inputs:
+            #     azureSubscription: ${{parameters.devOpsServiceConnection}}
+            #     appType: functionAppLinux
+            #     appName: "$(Terraform_Output.workers_app_name)"
+            #     package: "$(Pipeline.Workspace)/${{parameters.buildArtifactPipelineId}}/Workers/Workers.zip"
+            #     deploymentMethod: runFromPackage
+            #     appSettings: >
+            #       -AZURE_FUNCTIONS_ENVIRONMENT "${{parameters.runtimeEnvironment}}"
+
+            - task: AzureCLI@2
               displayName: "Deploy Workers Function"
               inputs:
                 azureSubscription: ${{parameters.devOpsServiceConnection}}
-                appType: functionAppLinux
-                appName: "$(Terraform_Output.workers_app_name)"
-                package: "$(Pipeline.Workspace)/${{parameters.buildArtifactPipelineId}}/Workers/Workers.zip"
-                deploymentMethod: runFromPackage
-                appSettings: >
-                  -AZURE_FUNCTIONS_ENVIRONMENT "${{parameters.runtimeEnvironment}}"
+                scriptType: "pscore"
+                scriptLocation: "inlineScript"
+                inlineScript: |
+                  az functionapp deployment source config-zip --src "$(Pipeline.Workspace)/${{parameters.buildArtifactPipelineId}}/Workers/Workers.zip" --name "$(Terraform_Output.workers_app_name)" --resource-group "$(Terraform_Output.rg_name)"
+                  az functionapp config appsettings set --name "$(Terraform_Output.workers_app_name)"  --resource-group "$(Terraform_Output.rg_name)" --settings AZURE_FUNCTIONS_ENVIRONMENT="${{parameters.runtimeEnvironment}}"

--- a/devops/rollout-deploy-stage-jobs.yml
+++ b/devops/rollout-deploy-stage-jobs.yml
@@ -158,4 +158,12 @@ jobs:
                 scriptLocation: "inlineScript"
                 inlineScript: |
                   az functionapp deployment source config-zip --src "$(Pipeline.Workspace)/${{parameters.buildArtifactPipelineId}}/Workers/Workers.zip" --name "$(Terraform_Output.workers_app_name)" --resource-group "$(Terraform_Output.rg_name)"
+
+            - task: AzureCLI@2
+              displayName: "Update Workers Function Settings"
+              inputs:
+                azureSubscription: ${{parameters.devOpsServiceConnection}}
+                scriptType: "pscore"
+                scriptLocation: "inlineScript"
+                inlineScript: |
                   az functionapp config appsettings set --name "$(Terraform_Output.workers_app_name)"  --resource-group "$(Terraform_Output.rg_name)" --settings AZURE_FUNCTIONS_ENVIRONMENT="${{parameters.runtimeEnvironment}}"


### PR DESCRIPTION
Change in rollout yaml file to fix issue with deployment getting stuck and failing sporadically, as explained here: https://github.com/microsoft/azure-pipelines-tasks/issues/18766