### PR TITLE
Fix cloud performance under load

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/IDataAccessBuilder.cs
+++ b/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/IDataAccessBuilder.cs
@@ -5,6 +5,12 @@ namespace OneBeyond.Studio.Obelisk.Infrastructure.DependencyInjection;
 
 public interface IDataAccessBuilder
 {
+    /// <summary>
+    /// Adds transaction scope to all requests. Note, in order to enable this, cloudDeployment must be disabled in AddDataAccess, as retries-on-failure is mutually incompatible with transaction scope.
+    /// </summary>
+    /// <param name="timeout"></param>
+    /// <param name="isolationLevel"></param>
+    /// <returns></returns>
     IDataAccessBuilder WithUnitOfWork(TimeSpan? timeout = default, IsolationLevel? isolationLevel = default);
 
     IDataAccessBuilder WithDomainEvents(bool isReceiverHost = false);

--- a/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -15,6 +15,14 @@ namespace OneBeyond.Studio.Obelisk.Infrastructure.DependencyInjection;
 
 public static class ServiceCollectionExtensions
 {
+    /// <summary>
+    /// Adds Data Access for DI
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configuration"></param>
+    /// <param name="cloudDeployment">This parameter is set to true by default. This allows for retries optimised for sql server, such that under load, the application continues to perform.</param>
+    /// <param name="configureDataAccessBuilder"></param>
+    /// <returns></returns>
     public static IServiceCollection AddDataAccess(
         this IServiceCollection services,
         IConfiguration configuration,

--- a/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/OneBeyond.Studio.Obelisk.Infrastructure/DependencyInjection/ServiceCollectionExtensions.cs
@@ -25,9 +25,9 @@ public static class ServiceCollectionExtensions
     /// <returns></returns>
     public static IServiceCollection AddDataAccess(
         this IServiceCollection services,
-        IConfiguration configuration,
-        bool cloudDeployment = true,
-        Action<IDataAccessBuilder>? configureDataAccessBuilder = default)
+        IConfiguration configuration,        
+        Action<IDataAccessBuilder>? configureDataAccessBuilder = default,
+        bool cloudDeployment = true)
     {
         EnsureArg.IsNotNull(services, nameof(services));
         EnsureArg.IsNotNull(configuration, nameof(configuration));


### PR DESCRIPTION
When deployed to Azure on 3x P1V3 App Service Plan + S3 database the application began to fail at approximately 500 requests/second. 

EnableRetriesOnFailure got this number to 25000 requests/second without trying. 

This occurs because when the number of requests increases on the cloud, the connection between the DB and the App Service is destroyed and recreated to a more powerful one, resulting in transient failures. 

[Connection Resliency - MSDN](https://learn.microsoft.com/en-us/ef/core/miscellaneous/connection-resiliency)

