### PR TITLE
BulkInsert can now handle columns that are Enums

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.Infrastructure/Data/BulkUpdate/PropertyMapping.cs
+++ b/src/OneBeyond.Studio.Obelisk.Infrastructure/Data/BulkUpdate/PropertyMapping.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using EnsureThat;
 using Microsoft.EntityFrameworkCore;
@@ -22,6 +23,13 @@ public sealed class PropertyMapping
         ColumnName = mappedDbColumn.Column.Name;
         IsNullable = mappedDbColumn.Column.IsNullable;
         ValueConverter = dbProperty.GetValueConverter();
+
+        if (dbProperty.ClrType.IsEnum && ValueConverter == null)
+        {
+            var underlyingType = Enum.GetUnderlyingType(dbProperty.ClrType);
+            var enumIsNullable = underlyingType.IsGenericType && underlyingType.GetGenericTypeDefinition() == typeof(Nullable<>);
+            DataType = enumIsNullable ? underlyingType.GetGenericArguments()[0].FullName! : underlyingType.FullName!;
+        }
 
         IsExcluded = false;
     }


### PR DESCRIPTION
Bulk insert repositories can now handle basic enums.

We check to see if the column type is an enum, and it is, get the underlying type and use that as the storage type. We only do this if a value converter has not been configured 