### PR TITLE
Terraform v4 upgrade

### DIFF
--- a/devops/Terraform/modules/random_password_in_key_vault/module.tf
+++ b/devops/Terraform/modules/random_password_in_key_vault/module.tf
@@ -5,7 +5,7 @@ resource "random_password" "sql_server_password" {
   min_numeric      = 1
   min_upper        = 1
   min_special      = 1
-  override_special = "!#$%*-_+?@.[]()"
+  override_special = "!#%*-_+?@.[]()"
 
   lifecycle {
     ignore_changes = [

--- a/devops/Terraform/providers.tf
+++ b/devops/Terraform/providers.tf
@@ -22,6 +22,7 @@ terraform {
 
 provider "azurerm" {
   subscription_id = "5c41ba40-6ca2-4e8a-9646-d3585df38b5a"
+  resource_provider_registrations = "none"
 
   features {
     resource_group {

--- a/devops/Terraform/providers.tf
+++ b/devops/Terraform/providers.tf
@@ -3,11 +3,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.116.0"
+      version = "4.10.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "2.53.1"
+      version = "3.0.2"
     }
     mssql = {
       source  = "betr-io/mssql"

--- a/devops/Terraform/storage.tf
+++ b/devops/Terraform/storage.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "stage" {
-  name                             = "${replace(local.resource_prefix, "-", "")}storage"
+  name                             = "${replace(replace(local.resource_prefix, "-", ""), "backend", "be")}storage" # must be between 3 & 24 chars
   resource_group_name              = azurerm_resource_group.stage.name
   location                         = azurerm_resource_group.stage.location
   account_tier                     = "Standard"

--- a/devops/Terraform/web-api.tf
+++ b/devops/Terraform/web-api.tf
@@ -40,6 +40,7 @@ resource "azurerm_linux_web_app" "web_api" {
     use_32_bit_worker     = false
     websockets_enabled    = true
     health_check_path     = "/health/ready"
+    health_check_eviction_time_in_min = 10
     application_stack {
       dotnet_version = "8.0"
     }

--- a/devops/infra-build-tfp-steps.yml
+++ b/devops/infra-build-tfp-steps.yml
@@ -23,7 +23,7 @@ steps:
     inputs:
       terraformVersion: latest
 
-  - task: TerraformTaskV3@3
+  - task: TerraformTaskV4@4
     displayName: 'Initialize TF'
     inputs:
       workingDirectory: '${{parameters.tfWorkingDirectory}}'
@@ -44,7 +44,7 @@ steps:
     displayName: 'Select TF Workspace'
     workingDirectory: '${{parameters.tfWorkingDirectory}}'
 
-  - task: TerraformTaskV3@3
+  - task: TerraformTaskV4@4
     name: Terraform_Plan
     displayName: 'Build TF Plan'
     inputs:

--- a/devops/rollout-deploy-stage-jobs.yml
+++ b/devops/rollout-deploy-stage-jobs.yml
@@ -101,7 +101,7 @@ jobs:
               inputs:
                 terraformVersion: latest
 
-            - task: TerraformTaskV3@3
+            - task: TerraformTaskV4@4
               displayName: "Apply TF Plan"
               inputs:
                 workingDirectory: "$(tf.workingDirectory)"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Provide the changes need to upgrade Obelisk to use Terraform V4, rather than V3.

## Description
Terraform V4 upgrade
1. Update version numbers in `infra-build-tfp-steps.yml` and   
`rollout-deploy-stage-jobs.yml` to V4@4

![image](https://github.com/user-attachments/assets/39bbb92f-4029-41ec-9763-3a2ac01ce221)

2. Change version number for Terraform in `providers.tf` to latest version (4+)
a. `4.10.0` from `3.x.x` for `azurerm`
b. `3.0.2` from `2.x.x` for `azuread`

![image](https://github.com/user-attachments/assets/a1038295-df59-47ab-952a-e06bbb4c41a9)

3. Add `resource_provider_registrations = "none"` to `providers.tf` under the section `provider "azurerm" {` beneath `subscription_id` and `tenant_id`.

Caution there is some debate about what the pipeline says versus what it means; Adding an additional `"` at the start of the error message. See below PRs for others issues.

https://github.com/hashicorp/terraform-provider-azurerm/pull/27144
https://github.com/hashicorp/terraform-provider-azurerm/issues/27110 

In addition to this, make sure you do `resource_provider_registrations` not `resource_provider_registration`. Note the `s` at the end.

4. Add a value `health_check_eviction_time_in_min = 10` to the `web-api.tf` under the `site_config` section as recommended by the pipeline. This value is meant to be set by default, but currently is not working. 

![image](https://github.com/user-attachments/assets/853dbe03-df75-4c0e-9087-a160437c74f2)

https://github.com/microsoft/PubSec-Info-Assistant/issues/860
https://github.com/microsoft/PubSec-Info-Assistant/pull/861

5. There is now a limit to the length of the storage account name in `Terraform/storage.tf` where it must be between 3 & 24 characters. I have combated this by reducing the `backend` prefix to just `be`. Longer project names could be an issue. E.g. onebeyondobeliskbackendqastorage.

`name                             = "${replace(replace(local.resource_prefix, "-", ""), "backend", "be")}storage" # must be between 3 & 24 chars`

![image](https://github.com/user-attachments/assets/484e93d1-235b-4d89-b188-d67eae01a8fd)

6. Update Random Password Generation to exclude the `$` sign.

![image](https://github.com/user-attachments/assets/04338c84-d4c0-4631-ac04-1aef0744ef92)

This caused an error for me where my password began with a `$`. So when performing the `Apply EF bundle` in the rollout pipeline, the EF bundler seems to have treated the `$FK` as a variable and stripped it out from the connection string, failing the login. 

![image](https://github.com/user-attachments/assets/35c88136-6884-4f63-b28e-e8c1418dc3b1)

![image](https://github.com/user-attachments/assets/25ad773b-3a7c-4ea6-ab47-2aae27c2dc1d)

If you do have this error, but haven't updated this code yet, you can just delete the $ in the password generator and Terraform will just create a new password, no need to delete the resource group and start again.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
(See motivation below)

## Motivation and Context
I am using Obelisk myself for my own personal project and required to do this change as TerraformV3@3 did not work and failed at Initialize TF stage in infra-pr.yml. I used v4 instead and had to do a couple of extra changes

`Error: Failed to get existing workspaces: Error retrieving keys for Storage Account "xxxinfrastorage": azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Storage/storageAccounts/<storage-account>/listKeys?api-version=2021-01-01: StatusCode=400 -- Original Error: adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"Identity not found"} Endpoint http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F`

![image](https://github.com/user-attachments/assets/c1a3dae2-4a5f-4754-afb8-ae649ee0929e)

## How Has This Been Tested?
I now have a functional and hosted in azure backend using V4 and frontend using [Obelisk Vuetify](https://github.com/onebeyond/onebeyond-studio-obelisk-fe-vuetify), which is also working with V4 (minimal changes there are needed.) Setting values to V4@4 & registrations... = none. Although the registrations change may not be needed. 

Further internal testing should be completed
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
