### PR TITLE
fix: expose health endpoints in all environments

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.ServiceDefaults/Extensions.cs
+++ b/src/OneBeyond.Studio.Obelisk.ServiceDefaults/Extensions.cs
@@ -115,17 +115,15 @@ public static class Extensions
     {
         // Adding health checks endpoints to applications in non-development environments has security implications.
         // See https://aka.ms/dotnet/aspire/healthchecks for details before enabling these endpoints in non-development environments.
-        if (app.Environment.IsDevelopment())
-        {
-            // All health checks must pass for app to be considered ready to accept traffic after starting
-            app.MapHealthChecks(HealthEndpointPath);
 
-            // Only health checks tagged with the "live" tag must pass for app to be considered alive
-            app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
-            {
-                Predicate = r => r.Tags.Contains(LiveTag)
-            });
-        }
+        // All health checks must pass for app to be considered ready to accept traffic after starting
+        app.MapHealthChecks(HealthEndpointPath);
+
+        // Only health checks tagged with the "live" tag must pass for app to be considered alive
+        app.MapHealthChecks(AlivenessEndpointPath, new HealthCheckOptions
+        {
+            Predicate = r => r.Tags.Contains(LiveTag)
+        });
 
         return app;
     }


### PR DESCRIPTION
This restores the previous behaviour which was overridden by Aspire's defaults. They're used in the standard Terraform setup for readiness checks.