### PR TITLE
Replace blocking Thread.Sleep with non-blocking Task.Delay in ForgotPassword

### DIFF
--- a/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
+++ b/src/OneBeyond.Studio.Obelisk.WebApi/Controllers/AuthController.cs
@@ -90,7 +90,7 @@ public sealed class AuthController : ControllerBase
         CancellationToken cancellationToken)
     {
         // To guard against timing attacks
-        Thread.Sleep(new Random().Next(1000, 3000));
+        await Task.Delay(new Random().Next(1000, 3000), cancellationToken);
 
         try
         {


### PR DESCRIPTION
    ## 📌 Summary
    Replaced synchronous `Thread.Sleep()` with asynchronous `await Task.Delay()` in the `ForgotPassword` endpoint within AuthController.cs.

    ## 💡 Rationale & Context
    To prevent email enumeration via timing attacks, a random delay (1–3 seconds) is introduced prior to generating and sending password reset tokens.

    Previously, `Thread.Sleep(...)` blocked the executing ASP.NET Core thread pool thread for the duration of the delay. Under high concurrency, blocking thread pool threads can lead to thread starvation
  and API performance degradation.

    Switching to `await Task.Delay(..., cancellationToken)` keeps the timing protection intact while releasing the thread back to the thread pool asynchronously. It also accepts `cancellationToken` so the
  operation can yield immediately if the HTTP request is aborted.